### PR TITLE
Set up development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,16 @@ Oxlint + Oxfmt's linter will catch most issues automatically. Focus your attenti
 ---
 
 Most formatting and common issues are automatically fixed by Oxlint + Oxfmt. Run `pnpm dlx ultracite fix` before committing to ensure compliance.
+
+---
+
+## Cursor Cloud specific instructions
+
+This repo is a single **Astro 6** website (`vbc-website`, Fresno Victory Baptist Church) deployed to Cloudflare Workers via the `@astrojs/cloudflare` adapter. There is no backend, database, or other service to run — the only service is the Astro dev server.
+
+- Package manager is **pnpm** (see `pnpm-lock.yaml` / `.npmrc` with `node-linker=hoisted`). Dependencies are refreshed automatically by the startup update script (`pnpm install`).
+- Run the dev server with `pnpm dev` — serves at `http://localhost:4321/`. Standard scripts live in `package.json` (`dev`, `build`, `preview`, `check`, `fix`, `generate-types`).
+- `pnpm build` runs `astro build` (adapter target is Cloudflare/`server` mode, output prerendered to `dist/`). `pnpm preview` builds then runs `wrangler dev`.
+- Lint/format: `pnpm check` (Ultracite/Oxlint+Oxfmt). Note the committed source currently has pre-existing formatting issues, so `pnpm check` exits non-zero on a clean checkout; that is not caused by your changes. Use `pnpm fix` to auto-format.
+- Cloudflare binding types are generated into `worker-configuration.d.ts` via `pnpm generate-types` (wrangler); `astro build` also regenerates types.
+- The R2 bucket binding (`fvbc_images`) uses local emulation by default (`"remote": false` in `wrangler.jsonc`), so no Cloudflare login is needed for local dev or builds.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the development environment for the `vbc-website` Astro site (Fresno Victory Baptist Church), which deploys to Cloudflare Workers.

## What was done

- Installed dependencies with `pnpm install` (pnpm 10.x, Node 22).
- Verified lint (`pnpm check` via Ultracite/Oxlint), build (`pnpm build`), and dev server (`pnpm dev` at `localhost:4321`).
- Completed a hello-world verification: browsed the live site and navigated between the homepage, `/visit/`, and `/sermons/` pages.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable, non-obvious run/lint/build notes for future agents.

## Verification

Navigation across pages works end-to-end on the running dev server.

[church_website_navigation_demo.mp4](https://cursor.com/agents/bc-8be460d3-dd1b-448d-91ef-6cea86a99019/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchurch_website_navigation_demo.mp4)

## Notes

- The only service in this repo is the Astro dev server; there is no backend/database.
- `pnpm check` exits non-zero on a clean checkout due to pre-existing formatting in committed source (not introduced here).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8be460d3-dd1b-448d-91ef-6cea86a99019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8be460d3-dd1b-448d-91ef-6cea86a99019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

