### PR TITLE
Pin Wrangler deploy to Zenitram Cloudflare account

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "vbc-website",
+  "account_id": "23f99d3ef188b488e18827b853b73295",
   "main": "@astrojs/cloudflare/entrypoints/server",
   "compatibility_date": "2025-09-27",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set `account_id` in `wrangler.jsonc` to the **Zenitram** Cloudflare account (`23f99d3ef188b488e18827b853b73295`) so deploys target Zenitram instead of the personal account that previously hosted `vbc-website`.
- Created the `fvbc-images` R2 bucket on Zenitram so the existing binding can resolve on deploy.
- Provisioned the `SESSION` KV namespace during first deploy on Zenitram.

## Deploy
Successfully deployed to Zenitram:

- **URL:** https://vbc-website.francisco-23f.workers.dev
- **Version ID:** `0601f561-10b4-49d9-a3f1-06ec41bf9d9b`
- **Bindings:** `SESSION` (KV), `fvbc_images` (R2), `ASSETS`

Note: the previous Worker remains on the personal Cloudflare account (`Martinez.fg11@gmail.com's Account`) until cleaned up separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7b31-ecc5-7b6d-af2f-50d39845da78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7b31-ecc5-7b6d-af2f-50d39845da78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

