### PR TITLE
Align page mobile nav with Visit Us as primary CTA

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -530,6 +530,9 @@ const gatherings = [
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 1.5rem;
+    padding: 5.5rem 1.25rem 2rem;
+    overflow-y: auto;
     clip-path: circle(0% at calc(100% - 2rem - 22px) calc(1.5rem + 22px));
     transition: clip-path 0.45s cubic-bezier(0.4, 0, 0.2, 1);
   }
@@ -551,7 +554,7 @@ const gatherings = [
     list-style: none;
     padding: 0;
     margin: 0;
-    width: 100%;
+    width: min(100%, 28rem);
   }
 
   .hero__mobile-item:not(:last-child) {
@@ -562,23 +565,21 @@ const gatherings = [
     display: block;
     width: 100%;
     text-align: center;
-    padding: 1.15rem 2rem;
+    padding: clamp(0.85rem, 2.5vh, 1.15rem) 1.25rem;
     color: #fff;
     text-decoration: none;
-    font-size: 1.75rem;
+    font-size: clamp(1.25rem, 5vw, 1.75rem);
     font-weight: 700;
     letter-spacing: -0.02em;
     font-family: var(--font-display);
   }
 
   .hero__mobile-cta {
-    position: absolute;
-    bottom: 2.5rem;
-    left: 0;
-    right: 0;
     display: flex;
     justify-content: center;
-    padding-inline: 2rem;
+    width: 100%;
+    padding-inline: 1.25rem;
+    margin-top: 0.5rem;
   }
 
   .hero__mobile-cta-btn {

--- a/src/components/site-header.astro
+++ b/src/components/site-header.astro
@@ -92,21 +92,23 @@ const { pathname } = Astro.url;
       </li>
     </ul>
 
-    <div class="site-header__cta">
-      <Button variant="cta" size="sm" href={visitHref}>Visit Us</Button>
-    </div>
+    <div class="site-header__actions">
+      <div class="site-header__cta">
+        <Button variant="cta" size="sm" href={visitHref}>Visit Us</Button>
+      </div>
 
-    <button
-      type="button"
-      class="site-header__hamburger"
-      aria-label="Open menu"
-      aria-expanded="false"
-      aria-controls="site-mobile-menu"
-    >
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
+      <button
+        type="button"
+        class="site-header__hamburger"
+        aria-label="Open menu"
+        aria-expanded="false"
+        aria-controls="site-mobile-menu"
+      >
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
   </nav>
 
   <nav
@@ -146,10 +148,10 @@ const { pathname } = Astro.url;
           Give
         </a>
       </li>
-      <li>
-        <a href={visitHref} class="site-header__mobile-link">Visit Us</a>
-      </li>
     </ul>
+    <div class="site-header__mobile-cta">
+      <a href={visitHref} class="site-header__mobile-cta-btn">Visit Us</a>
+    </div>
   </nav>
 </header>
 
@@ -164,6 +166,9 @@ const { pathname } = Astro.url;
       ".site-header__mobile-link"
     ),
   ];
+  const mobileCta = document.querySelector<HTMLAnchorElement>(
+    ".site-header__mobile-cta-btn"
+  );
   const desktopMedia = window.matchMedia("(min-width: 900px)");
 
   const isMenuOpen = () => menuButton?.getAttribute("aria-expanded") === "true";
@@ -197,7 +202,7 @@ const { pathname } = Astro.url;
 
   const getFocusableElements = () => {
     const logo = header?.querySelector<HTMLAnchorElement>(".site-header__logo");
-    return [logo, menuButton, ...mobileLinks].filter(
+    return [logo, menuButton, ...mobileLinks, mobileCta].filter(
       (element): element is HTMLElement => element !== null
     );
   };
@@ -238,6 +243,8 @@ const { pathname } = Astro.url;
   for (const link of mobileLinks) {
     link.addEventListener("click", () => setMenuOpen(false, false));
   }
+
+  mobileCta?.addEventListener("click", () => setMenuOpen(false, false));
 
   document.addEventListener("keydown", (event) => {
     if (!isMenuOpen()) {
@@ -422,8 +429,15 @@ const { pathname } = Astro.url;
     color: #fff;
   }
 
+  .site-header__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
   .site-header__cta {
-    display: none;
+    display: block;
   }
 
   .site-header__hamburger {
@@ -483,9 +497,13 @@ const { pathname } = Astro.url;
     inset: 0;
     z-index: 30;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 1.5rem;
+    padding: 5.5rem 1.25rem 2rem;
     visibility: hidden;
+    overflow-y: auto;
     background: rgba(15, 39, 68, 0.98);
     clip-path: circle(0% at calc(100% - 1.5rem - 22px) calc(0.875rem + 22px));
     pointer-events: none;
@@ -506,23 +524,57 @@ const { pathname } = Astro.url;
     z-index: 35;
   }
 
+  .site-header--menu-open .site-header__cta {
+    opacity: 0;
+    pointer-events: none;
+  }
+
   .site-header__mobile-links {
     list-style: none;
     margin: 0;
     padding: 0;
-    width: 100%;
+    width: min(100%, 28rem);
   }
 
   .site-header__mobile-link {
     display: block;
     text-align: center;
-    padding: 1.1rem 1.5rem;
+    padding: clamp(0.85rem, 2.5vh, 1.1rem) 1.25rem;
     color: #fff;
     text-decoration: none;
     font-family: var(--font-display);
-    font-size: 1.75rem;
+    font-size: clamp(1.25rem, 5vw, 1.75rem);
     font-weight: 700;
+    letter-spacing: -0.02em;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .site-header__mobile-cta {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    padding-inline: 1.25rem;
+    margin-top: 0.5rem;
+  }
+
+  .site-header__mobile-cta-btn {
+    display: block;
+    width: 100%;
+    max-width: 320px;
+    text-align: center;
+    padding: 1rem 2rem;
+    background: var(--cta);
+    color: #fff;
+    text-decoration: none;
+    font-size: 1rem;
+    font-weight: 700;
+    border-radius: 0.5rem;
+  }
+
+  @media (max-width: 380px) {
+    .site-header__brand {
+      display: none;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -539,15 +591,32 @@ const { pathname } = Astro.url;
 
     .site-header__links {
       display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      min-width: 0;
     }
 
-    .site-header__cta {
-      display: block;
+    .site-header__link,
+    .site-header__parent {
+      padding-inline: 0.6rem;
+      font-size: 0.875rem;
+    }
+
+    .site-header__actions {
+      margin-left: 0.5rem;
     }
 
     .site-header__hamburger,
     .site-header__mobile {
       display: none;
+    }
+  }
+
+  @media (min-width: 1100px) {
+    .site-header__link,
+    .site-header__parent {
+      padding-inline: 0.75rem;
+      font-size: 0.9375rem;
     }
   }
 </style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Page header mobile nav treated Visit Us as a plain list link, while the hero overlay already used it as a dedicated CTA. This brings the page nav in line and keeps other links readable across widths.

## Changes
- Keep Visit Us visible as the sticky header CTA on mobile (next to the hamburger)
- Style Visit Us as a dedicated CTA button in the mobile overlay (matching hero)
- Make the overlay scrollable with fluid link sizing so nav options stay readable on short/narrow screens
- Soften desktop link sizing between 900px–1100px so mid-width layouts don’t crowd
- Apply the same overlay sizing/scroll behavior to the hero mobile menu for consistency

## Screenshots
Mobile closed (Visit Us CTA in header):
[Page nav mobile closed](https://cursor.com/agents/bc-f3743fba-c088-449b-b69c-01b3eb8930d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpage-nav-mobile-closed.webp)

Mobile open (links + Visit Us CTA):
[Page nav mobile open](https://cursor.com/agents/bc-f3743fba-c088-449b-b69c-01b3eb8930d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpage-nav-mobile-open.webp)

Tablet/desktop links visible:
[Page nav tablet](https://cursor.com/agents/bc-f3743fba-c088-449b-b69c-01b3eb8930d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpage-nav-tablet.webp)

## Test plan
- [x] `/visit/` at ~390px — Visit Us CTA visible in header
- [x] Open hamburger — nav links readable, Visit Us CTA at bottom
- [x] ~360×640 — links scroll, no cutoff
- [x] ~1024px — desktop links + Visit Us visible without overflow
- [x] Home hero mobile menu — Visit Us remains the overlay CTA
- [x] `/about-vbc/` matches page-header behavior

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3743fba-c088-449b-b69c-01b3eb8930d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3743fba-c088-449b-b69c-01b3eb8930d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

