### PR TITLE
Fix Google Maps links failing to open on mobile

### DIFF
--- a/src/components/plan-visit-section.astro
+++ b/src/components/plan-visit-section.astro
@@ -1,7 +1,7 @@
 ---
 import { Button } from "@/components/starwind/button";
 import churchFrontage from "@/images/church_frontage.webp";
-import { serviceTimes } from "@/lib/church-data";
+import { churchInfo, serviceTimes } from "@/lib/church-data";
 
 const { bibleStudy, sundayMorning, sundaySchool } = serviceTimes;
 ---
@@ -72,13 +72,7 @@ const { bibleStudy, sundayMorning, sundaySchool } = serviceTimes;
 
     <div class="reveal reveal-delay-2 mt-9 flex flex-wrap gap-3">
       <Button href="/visit/" size="lg" variant="cta">Plan Your Visit</Button>
-      <Button
-        href="https://maps.app.goo.gl/Ysiz9UYS1mijVrJH7"
-        target="_blank"
-        rel="noopener noreferrer"
-        size="lg"
-        variant="outline"
-      >
+      <Button href={churchInfo.mapsUrl} size="lg" variant="outline">
         Open in Google Maps
       </Button>
     </div>

--- a/src/lib/church-data.ts
+++ b/src/lib/church-data.ts
@@ -21,8 +21,9 @@ export const churchInfo = {
   addressLine1: "1717 N Gateway Blvd Ste. #105",
   addressLine2: "Fresno, CA 93727",
   email: "contact@fresnovictory.com",
-  mapsUrl: "https://maps.app.goo.gl/Ysiz9UYS1mijVrJH7",
-  mapsUrlAlt: "https://goo.gl/maps/Tf3fDh44gbomRUrT9",
+  // Cross-platform Maps URL (short goo.gl links break on many mobile browsers)
+  mapsUrl:
+    "https://www.google.com/maps/search/?api=1&query=Victory+Baptist+Church%2C+1717+N+Gateway+Blvd+Ste.+105%2C+Fresno%2C+CA+93727",
   name: "Victory Baptist Church",
   shortName: "VBC",
 };

--- a/src/pages/visit.astro
+++ b/src/pages/visit.astro
@@ -99,12 +99,7 @@ const faqs = [
           Located in the Gateway Business Complex
         </p>
         <div class="flex flex-wrap gap-3">
-          <Button
-            href={churchInfo.mapsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            size="lg"
-          >
+          <Button href={churchInfo.mapsUrl} size="lg">
             Open in Google Maps
           </Button>
           <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Mobile users hitting **Open in Google Maps** were stuck on short `maps.app.goo.gl` / `goo.gl` links that often fail to hand off to the Maps app (or leave a blank browser tab when opened with `target="_blank"`).

## Changes
- Replace the short link with Google’s official cross-platform Maps URL API format pointing at Victory Baptist Church’s address
- Open Maps in the same tab (remove `target="_blank"`) so mobile can deep-link cleanly
- Use the shared `churchInfo.mapsUrl` on the home Plan Your Visit section instead of a hardcoded URL

## Test plan
- [ ] On a phone, tap **Open in Google Maps** from `/` (Plan Your Visit) and `/visit/`
- [ ] Confirm Google Maps opens to Victory Baptist Church / 1717 N Gateway Blvd Ste. 105, Fresno
- [ ] Confirm desktop still loads the place correctly

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9d23-0588-77d2-a73e-1d44e4019a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9d23-0588-77d2-a73e-1d44e4019a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

