### PR TITLE
Tint iOS Safari status bar to match header navy

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -41,7 +41,10 @@ const siteName = churchInfo.name;
 
 {/* Required base */}
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta
+  name="viewport"
+  content="width=device-width, initial-scale=1, viewport-fit=cover"
+/>
 <meta name="generator" content={Astro.generator} />
 <title>{title}</title>
 <meta name="description" content={description} />

--- a/src/layouts/main-layout.astro
+++ b/src/layouts/main-layout.astro
@@ -2,6 +2,7 @@
 import "@/styles/starwind.css";
 
 import BaseHead from "@/components/base-head.astro";
+import { churchInfo } from "@/lib/church-data";
 import { buildSEO } from "@/lib/seo";
 import type { SEOInput } from "@/lib/seo";
 
@@ -13,18 +14,44 @@ const { currentUrl, ...seoInput }: Props = Astro.props;
 const seo = buildSEO(seoInput);
 ---
 
-<html lang="en">
+<html lang="en" style={`--browser-chrome-tint: ${churchInfo.themeColor}`}>
   <head>
     <BaseHead {...seo} currentUrl={currentUrl ?? Astro.url} />
     <slot name="head-extra" />
   </head>
   <body class="font-sans antialiased">
+    {/*
+      Safari 26+ ignores theme-color and samples CSS instead. A fixed strip
+      at the top edge tints the status bar to match the navy header; html
+      covers overscroll when no fixed sample applies.
+    */}
+    <div class="browser-chrome-tint" aria-hidden="true"></div>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <slot />
   </body>
 </html>
 
 <style is:global>
+  html {
+    background-color: var(--browser-chrome-tint, #0f2744);
+  }
+
+  /*
+    Safari samples fixed/sticky elements within ~4px of the viewport edge.
+    Keep this a real element with background-color (not a ::before). Body
+    stays light so the bottom toolbar does not pick up the navy tint.
+  */
+  .browser-chrome-tint {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background-color: var(--browser-chrome-tint, #0f2744);
+    pointer-events: none;
+    z-index: 2147483646;
+  }
+
   .skip-link {
     position: fixed;
     top: 0.75rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On iOS Safari 26+, the top status/chrome bar no longer follows `<meta name="theme-color">`. Safari samples a fixed/sticky element’s `background-color` near the top of the viewport (then falls back to `html`/`body`). Because the homepage hero nav is transparent and `body` is white, Safari was painting a white bar above the navy header.

## Changes
- Add `viewport-fit=cover` to the viewport meta
- Set `html` background to the brand navy (`churchInfo.themeColor` / `#0f2744`)
- Add a 4px fixed top tint strip that Safari can sample for status-bar tinting
- Keep existing `theme-color` meta for Android / older Safari

## Test plan
- [ ] Open the homepage on iOS Safari — status bar area should match the navy header
- [ ] Confirm status bar icons are light against the dark tint
- [ ] Scroll the homepage — top tint should remain navy; bottom toolbar should stay light
- [ ] Check an inner page with the sticky navy header (e.g. `/visit/`)
- [ ] Spot-check Android Chrome still picks up `theme-color`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa1f9-5fc4-7981-a636-e958943118ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa1f9-5fc4-7981-a636-e958943118ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

