### PR TITLE
Fix iOS status bar tint (remove visible line)

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -384,7 +384,9 @@ const gatherings = [
   }
 
   .hero__nav {
-    position: absolute;
+    /* fixed + solid background-color: Safari 26 samples this for the status
+       bar (theme-color and transparent/absolute headers are ignored). */
+    position: fixed;
     top: 0;
     left: 0;
     right: 0;
@@ -392,8 +394,8 @@ const gatherings = [
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1.5rem 2rem;
-    background: transparent;
+    padding: calc(1.5rem + env(safe-area-inset-top, 0px)) 2rem 1.5rem;
+    background-color: #0f2744;
   }
 
   .hero__nav-cta {
@@ -579,12 +581,18 @@ const gatherings = [
     gap: 1.5rem;
     padding: 5.5rem 1.25rem 2rem;
     overflow-y: auto;
-    clip-path: circle(0% at calc(100% - 2rem - 22px) calc(1.5rem + 22px));
+    clip-path: circle(
+      0% at calc(100% - 2rem - 22px)
+        calc(1.5rem + env(safe-area-inset-top, 0px) + 22px)
+    );
     transition: clip-path 0.45s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   #hero-nav-cbox:checked ~ .hero__mobile-menu {
-    clip-path: circle(150% at calc(100% - 2rem - 22px) calc(1.5rem + 22px));
+    clip-path: circle(
+      150% at calc(100% - 2rem - 22px)
+        calc(1.5rem + env(safe-area-inset-top, 0px) + 22px)
+    );
   }
 
   .hero:has(#hero-nav-cbox:checked) .hero__nav {
@@ -646,7 +654,7 @@ const gatherings = [
     position: relative;
     z-index: 10;
     width: min(100%, 90rem);
-    padding: 7rem 1.5rem 4rem;
+    padding: calc(7rem + env(safe-area-inset-top, 0px)) 1.5rem 4rem;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -856,7 +864,13 @@ const gatherings = [
       display: grid;
       grid-template-columns: 1fr auto 1fr;
       align-items: center;
-      padding: calc(0.875rem + (1 - var(--p)) * 0.875rem) var(--nav-pad-x);
+      /* Solid color on the fixed element (not ::before) — Safari 26 samples it. */
+      background-color: #0f2744;
+      padding: calc(
+          0.875rem + env(safe-area-inset-top, 0px) + (1 - var(--p)) * 0.875rem
+        )
+        var(--nav-pad-x)
+        calc(0.875rem + (1 - var(--p)) * 0.875rem);
       border-bottom: 1px solid transparent;
     }
 

--- a/src/components/site-header.astro
+++ b/src/components/site-header.astro
@@ -273,7 +273,8 @@ const { pathname } = Astro.url;
   }
 
   .site-header--solid {
-    background: rgba(15, 39, 68, 0.97);
+    /* Solid (not rgba) so Safari 26 can sample a predictable status-bar tint. */
+    background-color: #0f2744;
     box-shadow: 0 1px 12px rgba(0, 0, 0, 0.18);
   }
 
@@ -282,7 +283,7 @@ const { pathname } = Astro.url;
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    padding: 0.875rem 1.5rem;
+    padding: calc(0.875rem + env(safe-area-inset-top, 0px)) 1.5rem 0.875rem;
     max-width: 80rem;
     margin-inline: auto;
   }
@@ -505,7 +506,10 @@ const { pathname } = Astro.url;
     visibility: hidden;
     overflow-y: auto;
     background: rgba(15, 39, 68, 0.98);
-    clip-path: circle(0% at calc(100% - 1.5rem - 22px) calc(0.875rem + 22px));
+    clip-path: circle(
+      0% at calc(100% - 1.5rem - 22px)
+        calc(0.875rem + env(safe-area-inset-top, 0px) + 22px)
+    );
     pointer-events: none;
     transition:
       clip-path 0.4s cubic-bezier(0.4, 0, 0.2, 1),
@@ -514,7 +518,10 @@ const { pathname } = Astro.url;
 
   .site-header__mobile.is-open {
     visibility: visible;
-    clip-path: circle(150% at calc(100% - 1.5rem - 22px) calc(0.875rem + 22px));
+    clip-path: circle(
+      150% at calc(100% - 1.5rem - 22px)
+        calc(0.875rem + env(safe-area-inset-top, 0px) + 22px)
+    );
     pointer-events: auto;
     transition-delay: 0s;
   }

--- a/src/layouts/main-layout.astro
+++ b/src/layouts/main-layout.astro
@@ -20,36 +20,19 @@ const seo = buildSEO(seoInput);
     <slot name="head-extra" />
   </head>
   <body class="font-sans antialiased">
-    {/*
-      Safari 26+ ignores theme-color and samples CSS instead. A fixed strip
-      at the top edge tints the status bar to match the navy header; html
-      covers overscroll when no fixed sample applies.
-    */}
-    <div class="browser-chrome-tint" aria-hidden="true"></div>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <slot />
   </body>
 </html>
 
 <style is:global>
-  html {
-    background-color: var(--browser-chrome-tint, #0f2744);
-  }
-
   /*
-    Safari samples fixed/sticky elements within ~4px of the viewport edge.
-    Keep this a real element with background-color (not a ::before). Body
-    stays light so the bottom toolbar does not pick up the navy tint.
+    Safari 26+ ignores theme-color and html background. It samples
+    fixed/sticky backgrounds near the viewport edge, then body.
+    Body must be the header navy so the iOS status bar matches.
   */
-  .browser-chrome-tint {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 4px;
+  body {
     background-color: var(--browser-chrome-tint, #0f2744);
-    pointer-events: none;
-    z-index: 2147483646;
   }
 
   .skip-link {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to #25. The 4px fixed tint strip showed as a line through the logo and did **not** turn the iOS status bar navy.

Safari 26 ignores `theme-color` and **`html` background**. It samples a fixed/sticky element’s solid `background-color`, then **`body`**.

## Changes
- Remove the visible tint strip
- Set `body` to header navy (`#0f2744`)
- Solid navy `background-color` on the fixed homepage nav and sticky site header (not on a `::before`)
- `safe-area-inset-top` padding so the logo clears the status bar under `viewport-fit=cover`

## Test plan
- [ ] Hard-refresh on iPhone Safari — no line through the logo
- [ ] Status bar area matches the navy header; icons should be light
- [ ] Scroll homepage and check an inner page (e.g. `/visit/`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa1f9-5fc4-7981-a636-e958943118ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa1f9-5fc4-7981-a636-e958943118ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

