### PR TITLE
Undo iOS status bar tint PRs (#25, #26)

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -41,10 +41,7 @@ const siteName = churchInfo.name;
 
 {/* Required base */}
 <meta charset="utf-8" />
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, viewport-fit=cover"
-/>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="generator" content={Astro.generator} />
 <title>{title}</title>
 <meta name="description" content={description} />

--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -384,9 +384,7 @@ const gatherings = [
   }
 
   .hero__nav {
-    /* fixed + solid background-color: Safari 26 samples this for the status
-       bar (theme-color and transparent/absolute headers are ignored). */
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     right: 0;
@@ -394,8 +392,8 @@ const gatherings = [
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: calc(1.5rem + env(safe-area-inset-top, 0px)) 2rem 1.5rem;
-    background-color: #0f2744;
+    padding: 1.5rem 2rem;
+    background: transparent;
   }
 
   .hero__nav-cta {
@@ -581,18 +579,12 @@ const gatherings = [
     gap: 1.5rem;
     padding: 5.5rem 1.25rem 2rem;
     overflow-y: auto;
-    clip-path: circle(
-      0% at calc(100% - 2rem - 22px)
-        calc(1.5rem + env(safe-area-inset-top, 0px) + 22px)
-    );
+    clip-path: circle(0% at calc(100% - 2rem - 22px) calc(1.5rem + 22px));
     transition: clip-path 0.45s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   #hero-nav-cbox:checked ~ .hero__mobile-menu {
-    clip-path: circle(
-      150% at calc(100% - 2rem - 22px)
-        calc(1.5rem + env(safe-area-inset-top, 0px) + 22px)
-    );
+    clip-path: circle(150% at calc(100% - 2rem - 22px) calc(1.5rem + 22px));
   }
 
   .hero:has(#hero-nav-cbox:checked) .hero__nav {
@@ -654,7 +646,7 @@ const gatherings = [
     position: relative;
     z-index: 10;
     width: min(100%, 90rem);
-    padding: calc(7rem + env(safe-area-inset-top, 0px)) 1.5rem 4rem;
+    padding: 7rem 1.5rem 4rem;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -864,13 +856,7 @@ const gatherings = [
       display: grid;
       grid-template-columns: 1fr auto 1fr;
       align-items: center;
-      /* Solid color on the fixed element (not ::before) — Safari 26 samples it. */
-      background-color: #0f2744;
-      padding: calc(
-          0.875rem + env(safe-area-inset-top, 0px) + (1 - var(--p)) * 0.875rem
-        )
-        var(--nav-pad-x)
-        calc(0.875rem + (1 - var(--p)) * 0.875rem);
+      padding: calc(0.875rem + (1 - var(--p)) * 0.875rem) var(--nav-pad-x);
       border-bottom: 1px solid transparent;
     }
 

--- a/src/components/site-header.astro
+++ b/src/components/site-header.astro
@@ -273,8 +273,7 @@ const { pathname } = Astro.url;
   }
 
   .site-header--solid {
-    /* Solid (not rgba) so Safari 26 can sample a predictable status-bar tint. */
-    background-color: #0f2744;
+    background: rgba(15, 39, 68, 0.97);
     box-shadow: 0 1px 12px rgba(0, 0, 0, 0.18);
   }
 
@@ -283,7 +282,7 @@ const { pathname } = Astro.url;
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    padding: calc(0.875rem + env(safe-area-inset-top, 0px)) 1.5rem 0.875rem;
+    padding: 0.875rem 1.5rem;
     max-width: 80rem;
     margin-inline: auto;
   }
@@ -506,10 +505,7 @@ const { pathname } = Astro.url;
     visibility: hidden;
     overflow-y: auto;
     background: rgba(15, 39, 68, 0.98);
-    clip-path: circle(
-      0% at calc(100% - 1.5rem - 22px)
-        calc(0.875rem + env(safe-area-inset-top, 0px) + 22px)
-    );
+    clip-path: circle(0% at calc(100% - 1.5rem - 22px) calc(0.875rem + 22px));
     pointer-events: none;
     transition:
       clip-path 0.4s cubic-bezier(0.4, 0, 0.2, 1),
@@ -518,10 +514,7 @@ const { pathname } = Astro.url;
 
   .site-header__mobile.is-open {
     visibility: visible;
-    clip-path: circle(
-      150% at calc(100% - 1.5rem - 22px)
-        calc(0.875rem + env(safe-area-inset-top, 0px) + 22px)
-    );
+    clip-path: circle(150% at calc(100% - 1.5rem - 22px) calc(0.875rem + 22px));
     pointer-events: auto;
     transition-delay: 0s;
   }

--- a/src/layouts/main-layout.astro
+++ b/src/layouts/main-layout.astro
@@ -20,19 +20,36 @@ const seo = buildSEO(seoInput);
     <slot name="head-extra" />
   </head>
   <body class="font-sans antialiased">
+    {/*
+      Safari 26+ ignores theme-color and samples CSS instead. A fixed strip
+      at the top edge tints the status bar to match the navy header; html
+      covers overscroll when no fixed sample applies.
+    */}
+    <div class="browser-chrome-tint" aria-hidden="true"></div>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <slot />
   </body>
 </html>
 
 <style is:global>
-  /*
-    Safari 26+ ignores theme-color and html background. It samples
-    fixed/sticky backgrounds near the viewport edge, then body.
-    Body must be the header navy so the iOS status bar matches.
-  */
-  body {
+  html {
     background-color: var(--browser-chrome-tint, #0f2744);
+  }
+
+  /*
+    Safari samples fixed/sticky elements within ~4px of the viewport edge.
+    Keep this a real element with background-color (not a ::before). Body
+    stays light so the bottom toolbar does not pick up the navy tint.
+  */
+  .browser-chrome-tint {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background-color: var(--browser-chrome-tint, #0f2744);
+    pointer-events: none;
+    z-index: 2147483646;
   }
 
   .skip-link {

--- a/src/layouts/main-layout.astro
+++ b/src/layouts/main-layout.astro
@@ -2,7 +2,6 @@
 import "@/styles/starwind.css";
 
 import BaseHead from "@/components/base-head.astro";
-import { churchInfo } from "@/lib/church-data";
 import { buildSEO } from "@/lib/seo";
 import type { SEOInput } from "@/lib/seo";
 
@@ -14,44 +13,18 @@ const { currentUrl, ...seoInput }: Props = Astro.props;
 const seo = buildSEO(seoInput);
 ---
 
-<html lang="en" style={`--browser-chrome-tint: ${churchInfo.themeColor}`}>
+<html lang="en">
   <head>
     <BaseHead {...seo} currentUrl={currentUrl ?? Astro.url} />
     <slot name="head-extra" />
   </head>
   <body class="font-sans antialiased">
-    {/*
-      Safari 26+ ignores theme-color and samples CSS instead. A fixed strip
-      at the top edge tints the status bar to match the navy header; html
-      covers overscroll when no fixed sample applies.
-    */}
-    <div class="browser-chrome-tint" aria-hidden="true"></div>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <slot />
   </body>
 </html>
 
 <style is:global>
-  html {
-    background-color: var(--browser-chrome-tint, #0f2744);
-  }
-
-  /*
-    Safari samples fixed/sticky elements within ~4px of the viewport edge.
-    Keep this a real element with background-color (not a ::before). Body
-    stays light so the bottom toolbar does not pick up the navy tint.
-  */
-  .browser-chrome-tint {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 4px;
-    background-color: var(--browser-chrome-tint, #0f2744);
-    pointer-events: none;
-    z-index: 2147483646;
-  }
-
   .skip-link {
     position: fixed;
     top: 0.75rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Reverts #25 and #26 (iOS Safari status bar tint experiments). Restores header/layout/`theme-color` behavior to the pre-change state.

## Changes
- Revert “Fix iOS status bar tint without visible line (#26)”
- Revert “Tint iOS Safari status bar to match header navy (#25)”

## Test plan
- [ ] Homepage header looks as before (no tint strip, no forced navy body)
- [ ] Inner pages with sticky header unchanged
- [ ] Spot-check mobile Safari layout around the logo/status bar

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa1f9-5fc4-7981-a636-e958943118ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa1f9-5fc4-7981-a636-e958943118ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

