### PR TITLE
Disable home hero fade-ins on mobile

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -828,9 +828,19 @@ const gatherings = [
     }
   }
 
+  /* Mobile header is visible below 768px — skip content fade-ins so the
+     hero copy is immediate under the sticky chrome. */
   @media (max-width: 767px) {
     .hero__actions {
       flex-direction: column;
+    }
+
+    .hero__eyebrow,
+    .hero__headline,
+    .hero__support,
+    .hero__actions,
+    .hero__times {
+      animation: none;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- On viewports under 768px (when the mobile header/hamburger is showing), disable the home hero `fade-up` entrance animations for headline, support copy, CTAs, eyebrow, and service times.
- Desktop fade-ins and other motion (ken burns / glows) are unchanged.

## Test plan
- [x] Open `/` at a mobile width and hard-refresh: hero text and buttons appear immediately with no fade/slide-up.
- [x] Confirm the mobile header (logo + hamburger) is visible in that same viewport.
- [ ] Open `/` at desktop width: fade-up entrance animations still run.
- [ ] With `prefers-reduced-motion: reduce`, animations remain off at all sizes.

### Mobile verification
[Mobile home hero with no fade-in](https://cursor.com/agents/bc-019fa209-b433-7957-8a3f-752366f8c182/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-hero-mobile-no-fade.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa209-b433-7957-8a3f-752366f8c182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa209-b433-7957-8a3f-752366f8c182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

