### PR TITLE
Use shared SiteHeader for homepage mobile nav

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -1,18 +1,8 @@
 ---
 import heroBg from "@/images/home-page_fvbc_hero.webp";
 import { Button } from "@/components/starwind/button";
-import { churchInfo, serviceTimes } from "@/lib/church-data";
+import { serviceTimes } from "@/lib/church-data";
 import { giveHref, primaryNav, visitHref } from "@/lib/site-nav";
-
-const mobileLinks = [
-  ...primaryNav.flatMap((item) =>
-    item.children
-      ? item.children.map((child) => ({ href: child.href, label: child.label }))
-      : [{ href: item.href ?? "/", label: item.label }]
-  ),
-  { external: true, href: giveHref, label: "Give" },
-  { href: "/#soul-winning", label: "Ministries" },
-];
 
 const gatherings = [
   { label: "Sunday School", time: serviceTimes.sundaySchool.time },
@@ -46,13 +36,7 @@ const gatherings = [
     <div class="hero__grain"></div>
   </div>
 
-  <input
-    type="checkbox"
-    id="hero-nav-cbox"
-    class="hero__cbox"
-    aria-hidden="true"
-  />
-
+  {/* Desktop-only: mobile uses the shared SiteHeader from the homepage. */}
   <nav class="hero__nav" aria-label="Main navigation">
     <a href="/" class="hero__logo" aria-label="Home">
       <img
@@ -109,41 +93,7 @@ const gatherings = [
     <div class="hero__nav-cta">
       <Button variant="cta" size="sm" href={visitHref}>Visit Us</Button>
     </div>
-
-    <label for="hero-nav-cbox" class="hero__hamburger" aria-label="Toggle menu">
-      <span class="hero__hamburger-bar"></span>
-      <span class="hero__hamburger-bar"></span>
-      <span class="hero__hamburger-bar"></span>
-    </label>
   </nav>
-
-  <div class="hero__mobile-menu" id="mobile-menu">
-    <ul class="hero__mobile-links" role="list">
-      {
-        mobileLinks.map((link) => (
-          <li class="hero__mobile-item">
-            <a
-              href={link.href}
-              class="hero__mobile-link"
-              target={
-                "external" in link && link.external ? "_blank" : undefined
-              }
-              rel={
-                "external" in link && link.external
-                  ? "noopener noreferrer"
-                  : undefined
-              }
-            >
-              {link.label}
-            </a>
-          </li>
-        ))
-      }
-    </ul>
-    <div class="hero__mobile-cta">
-      <a href={visitHref} class="hero__mobile-cta-btn">Visit Us</a>
-    </div>
-  </div>
 
   <div class="hero__content">
     <h1 class="hero__headline">
@@ -178,31 +128,6 @@ const gatherings = [
 </section>
 
 <script>
-  const cbox = document.querySelector(
-    "#hero-nav-cbox"
-  ) as HTMLInputElement | null;
-
-  const closeMenu = () => {
-    if (cbox) {
-      cbox.checked = false;
-    }
-    document.body.style.overflow = "";
-  };
-
-  cbox?.addEventListener("change", () => {
-    document.body.style.overflow = cbox.checked ? "hidden" : "";
-  });
-
-  for (const link of document.querySelectorAll(".hero__mobile-link")) {
-    link.addEventListener("click", closeMenu);
-  }
-
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && cbox?.checked) {
-      closeMenu();
-    }
-  });
-
   const hero = document.querySelector(".hero") as HTMLElement | null;
   const nav = document.querySelector(".hero__nav") as HTMLElement | null;
   let navTicking = false;
@@ -231,7 +156,8 @@ const gatherings = [
     if (!(hero && nav)) {
       return;
     }
-    const scrolled = window.innerWidth >= 768 && window.scrollY > 10;
+    // Match SiteHeader desktop breakpoint — hero nav is desktop-only.
+    const scrolled = window.innerWidth >= 900 && window.scrollY > 10;
     if (navInitialized) {
       applyNavState(scrolled);
       return;
@@ -383,17 +309,9 @@ const gatherings = [
     pointer-events: none;
   }
 
+  /* Hidden on mobile — SiteHeader owns the homepage navbar there. */
   .hero__nav {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 20;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1.5rem 2rem;
-    background: transparent;
+    display: none;
   }
 
   .hero__nav-cta {
@@ -413,7 +331,6 @@ const gatherings = [
   }
 
   .hero__nav-links {
-    display: none;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -519,134 +436,11 @@ const gatherings = [
     color: #fff;
   }
 
-  .hero__cbox {
-    display: none;
-  }
-
-  .hero__hamburger {
-    position: relative;
-    display: block;
-    width: 44px;
-    height: 44px;
-    overflow: hidden;
-    background-color: transparent;
-    cursor: pointer;
-  }
-
-  .hero__hamburger-bar {
-    position: absolute;
-    display: block;
-    background-color: #fff;
-    width: 26px;
-    height: 2px;
-    border-radius: 2px;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    transition: all 300ms ease-in-out;
-  }
-
-  .hero__hamburger-bar:nth-child(1) {
-    top: 35%;
-  }
-  .hero__hamburger-bar:nth-child(2) {
-    top: 50%;
-  }
-  .hero__hamburger-bar:nth-child(3) {
-    top: 65%;
-  }
-
-  #hero-nav-cbox:checked ~ .hero__nav .hero__hamburger-bar:nth-child(1) {
-    top: 50%;
-    transform: translate(-50%, -50%) rotate(45deg);
-  }
-  #hero-nav-cbox:checked ~ .hero__nav .hero__hamburger-bar:nth-child(2) {
-    left: -150%;
-  }
-  #hero-nav-cbox:checked ~ .hero__nav .hero__hamburger-bar:nth-child(3) {
-    top: 50%;
-    transform: translate(-50%, -50%) rotate(-45deg);
-  }
-
-  .hero__mobile-menu {
-    position: fixed;
-    inset: 0;
-    z-index: 100;
-    background: rgba(5, 13, 28, 0.97);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 1.5rem;
-    padding: 5.5rem 1.25rem 2rem;
-    overflow-y: auto;
-    clip-path: circle(0% at calc(100% - 2rem - 22px) calc(1.5rem + 22px));
-    transition: clip-path 0.45s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  #hero-nav-cbox:checked ~ .hero__mobile-menu {
-    clip-path: circle(150% at calc(100% - 2rem - 22px) calc(1.5rem + 22px));
-  }
-
-  .hero:has(#hero-nav-cbox:checked) .hero__nav {
-    z-index: 101;
-  }
-
-  .hero:has(#hero-nav-cbox:checked) .hero__logo {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .hero__mobile-links {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    width: min(100%, 28rem);
-  }
-
-  .hero__mobile-item:not(:last-child) {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-  }
-
-  .hero__mobile-link {
-    display: block;
-    width: 100%;
-    text-align: center;
-    padding: clamp(0.85rem, 2.5vh, 1.15rem) 1.25rem;
-    color: #fff;
-    text-decoration: none;
-    font-size: clamp(1.25rem, 5vw, 1.75rem);
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    font-family: var(--font-display);
-  }
-
-  .hero__mobile-cta {
-    display: flex;
-    justify-content: center;
-    width: 100%;
-    padding-inline: 1.25rem;
-    margin-top: 0.5rem;
-  }
-
-  .hero__mobile-cta-btn {
-    display: block;
-    width: 100%;
-    max-width: 320px;
-    text-align: center;
-    padding: 1rem 2rem;
-    background: var(--cta);
-    color: #fff;
-    text-decoration: none;
-    font-size: 1rem;
-    font-weight: 700;
-    border-radius: 0.5rem;
-  }
-
   .hero__content {
     position: relative;
     z-index: 10;
     width: min(100%, 90rem);
-    padding: 7rem 1.5rem 4rem;
+    padding: 4rem 1.5rem 4rem;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -828,13 +622,9 @@ const gatherings = [
     }
   }
 
-  /* Mobile header is visible below 768px — skip content fade-ins so the
-     hero copy is immediate under the sticky chrome. */
-  @media (max-width: 767px) {
-    .hero__actions {
-      flex-direction: column;
-    }
-
+  /* Shared SiteHeader is the mobile chrome (<900px) — skip content fade-ins
+     so the hero copy is immediate under it. */
+  @media (max-width: 899px) {
     .hero__eyebrow,
     .hero__headline,
     .hero__support,
@@ -844,15 +634,31 @@ const gatherings = [
     }
   }
 
+  @media (max-width: 767px) {
+    .hero__actions {
+      flex-direction: column;
+    }
+  }
+
   @media (min-width: 768px) {
     .hero__eyebrow {
       display: inline-flex;
     }
 
-    /* Desktop header: at the top of the page (--p = 0) the logo is large and
-       top-centered with the nav links stacked below it. The first scroll
-       flips --p to 1, gliding the logo into its small left-hand slot and
-       lifting the links into the bar. */
+    .hero__content {
+      padding: 8rem 3rem 9rem;
+    }
+
+    .hero__times {
+      display: flex;
+    }
+  }
+
+  /* Desktop header (matches SiteHeader breakpoint): at the top of the page
+     (--p = 0) the logo is large and top-centered with the nav links stacked
+     below it. The first scroll flips --p to 1, gliding the logo into its
+     small left-hand slot and lifting the links into the bar. */
+  @media (min-width: 900px) {
     .hero__nav {
       --logo-w: 8rem;
       --logo-h: calc(var(--logo-w) * 0.53125); /* logo aspect: 128 × 68 */
@@ -863,11 +669,16 @@ const gatherings = [
       --nav-pad-x: 4rem;
 
       position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 20;
       display: grid;
       grid-template-columns: 1fr auto 1fr;
       align-items: center;
       padding: calc(0.875rem + (1 - var(--p)) * 0.875rem) var(--nav-pad-x);
       border-bottom: 1px solid transparent;
+      background: transparent;
     }
 
     /* Scrolled bar chrome fades in behind the content so blur stays constant. */
@@ -905,10 +716,6 @@ const gatherings = [
       max-width: none;
     }
 
-    .hero__hamburger {
-      display: none;
-    }
-
     .hero__nav-links {
       display: flex;
       justify-content: center;
@@ -934,15 +741,11 @@ const gatherings = [
     .hero__content {
       padding: calc(8rem + (1 - var(--p)) * 5rem) 3rem 9rem;
     }
-
-    .hero__times {
-      display: flex;
-    }
   }
 
   /* Shorter desktop viewports: shrink the stacked header so it cannot
      collide with the hero headline. */
-  @media (min-width: 768px) and (max-height: 760px) {
+  @media (min-width: 900px) and (max-height: 760px) {
     .hero__nav {
       --logo-scale: 2;
     }
@@ -953,7 +756,7 @@ const gatherings = [
   }
 
   /* Narrow desktops: tighter chrome so logo + links fit without overlap. */
-  @media (min-width: 768px) and (max-width: 1023px) {
+  @media (min-width: 900px) and (max-width: 1023px) {
     .hero__nav {
       --nav-pad-x: 1.5rem;
       --logo-w: 6.5rem;

--- a/src/components/site-header.astro
+++ b/src/components/site-header.astro
@@ -4,14 +4,20 @@ import { giveHref, primaryNav, visitHref } from "@/lib/site-nav";
 
 interface Props {
   variant?: "solid" | "transparent";
+  /** When true, hide at the desktop breakpoint so a page-specific header can take over. */
+  mobileOnly?: boolean;
 }
 
-const { variant = "solid" }: Props = Astro.props;
+const { variant = "solid", mobileOnly = false }: Props = Astro.props;
 const { pathname } = Astro.url;
 ---
 
 <header
-  class:list={["site-header", variant === "solid" && "site-header--solid"]}
+  class:list={[
+    "site-header",
+    variant === "solid" && "site-header--solid",
+    mobileOnly && "site-header--mobile-only",
+  ]}
 >
   <nav class="site-header__nav" aria-label="Main navigation">
     <a
@@ -585,6 +591,10 @@ const { pathname } = Astro.url;
   }
 
   @media (min-width: 900px) {
+    .site-header--mobile-only {
+      display: none;
+    }
+
     .site-header__nav {
       padding-inline: 2.5rem;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 // oxlint-disable import/no-relative-parent-imports
 import MainLayout from "../layouts/main-layout.astro";
+import SiteHeader from "../components/site-header.astro";
 import HeroComponent from "../components/hero-component.astro";
 import MinistriesSection from "../components/ministries-section.astro";
 import AboutSection from "../components/about-section.astro";
@@ -20,6 +21,7 @@ import { churchOrganizationLd } from "@/lib/seo";
   <Fragment slot="head-extra">
     <link rel="preload" as="image" href={heroBg.src} fetchpriority="high" />
   </Fragment>
+  <SiteHeader mobileOnly />
   <main id="main-content" class="site-main" tabindex="-1">
     <HeroComponent />
     <MinistriesSection />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Homepage mobile navigation now uses the same `SiteHeader` component as the rest of the site (solid sticky bar + hamburger overlay).
- Removed the homepage-only hero hamburger / checkbox mobile menu so mobile no longer has a competing nav.
- Desktop homepage keeps the special hero nav morph; `SiteHeader` is `mobileOnly` and hidden from the 900px desktop breakpoint up, matching `SiteHeader`’s own mobile cutoff.

## Test plan
- [x] On a phone-width viewport of `/`, confirm only the shared navy `SiteHeader` appears (logo + brand text + Visit Us + hamburger), with no hero hamburger overlay.
- [x] Open the mobile menu and confirm links/behavior match other pages (e.g. `/about-vbc/`).
- [x] At ≥900px on `/`, confirm `SiteHeader` is hidden and the hero desktop nav morph still works on scroll.
- [x] Spot-check a non-home page still shows the normal sticky header on mobile and desktop.

## Screenshots
[Homepage mobile header](https://cursor.com/agents/bc-019fa20e-d92b-757e-a48f-feb2619ee54a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage-mobile-header.webp)
[Homepage mobile menu](https://cursor.com/agents/bc-019fa20e-d92b-757e-a48f-feb2619ee54a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage-mobile-menu.webp)
[About page mobile header](https://cursor.com/agents/bc-019fa20e-d92b-757e-a48f-feb2619ee54a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fabout-mobile-header.webp)
[Homepage desktop hero nav](https://cursor.com/agents/bc-019fa20e-d92b-757e-a48f-feb2619ee54a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage-desktop-hero-nav.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa20e-d92b-757e-a48f-feb2619ee54a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa20e-d92b-757e-a48f-feb2619ee54a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

