### PR TITLE
Disable home section reveal fades on mobile

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -252,7 +252,15 @@ const gatherings = [
   updateNav();
 
   const revealEls = document.querySelectorAll(".reveal");
-  if (revealEls.length > 0 && "IntersectionObserver" in window) {
+  const prefersInstantReveal =
+    window.matchMedia("(max-width: 767px)").matches ||
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  if (
+    revealEls.length > 0 &&
+    "IntersectionObserver" in window &&
+    !prefersInstantReveal
+  ) {
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {

--- a/src/styles/starwind.css
+++ b/src/styles/starwind.css
@@ -224,4 +224,18 @@
   .reveal-delay-2 {
     transition-delay: 0.2s;
   }
+
+  /* Mobile header breakpoint — keep section content visible with no fade. */
+  @media (max-width: 767px) {
+    .reveal {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+
+    .reveal-delay-1,
+    .reveal-delay-2 {
+      transition-delay: 0s;
+    }
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- On viewports under 768px, disable scroll-reveal fade/slide transitions for home sections (`.reveal`).
- Skip the IntersectionObserver on mobile (and when `prefers-reduced-motion: reduce`) so section content is marked visible immediately.
- Follow-up to #28, which already removed hero fade-ups on mobile.

## Test plan
- [x] Open `/` at mobile width, hard-refresh, and scroll home sections: content is fully visible with no fade/slide-up.
- [ ] At desktop width, section reveal fades still run on scroll.
- [ ] With `prefers-reduced-motion: reduce`, reveals stay off.

### Mobile verification
[Ministries section on mobile with no reveal fade](https://cursor.com/agents/bc-019fa209-b433-7957-8a3f-752366f8c182/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-ministries-mobile-no-fade.webp)
[Soul-Winning section on mobile with no reveal fade](https://cursor.com/agents/bc-019fa209-b433-7957-8a3f-752366f8c182/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-soul-winning-mobile-no-fade.webp)
[Children and Teens sections on mobile with no reveal fade](https://cursor.com/agents/bc-019fa209-b433-7957-8a3f-752366f8c182/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-children-teens-mobile-no-fade.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa209-b433-7957-8a3f-752366f8c182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa209-b433-7957-8a3f-752366f8c182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

