### PR TITLE
Fix iOS Safari mobile layout and interaction bugs

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -383,15 +383,20 @@ const gatherings = [
     transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
   }
 
-  .hero__nav-link:hover,
-  .hero__nav-parent:hover {
-    color: #fff;
-  }
-
-  .hero__nav-link:hover::after,
-  .hero__nav-parent:hover::after,
   .hero__nav-item--has-children:focus-within .hero__nav-parent::after {
     transform: scaleX(1);
+  }
+
+  @media (hover: hover) {
+    .hero__nav-link:hover,
+    .hero__nav-parent:hover {
+      color: #fff;
+    }
+
+    .hero__nav-link:hover::after,
+    .hero__nav-parent:hover::after {
+      transform: scaleX(1);
+    }
   }
 
   .hero__caret {
@@ -633,6 +638,10 @@ const gatherings = [
   /* Shared SiteHeader is the mobile chrome (<900px) — skip content fade-ins
      so the hero copy is immediate under it. */
   @media (max-width: 899px) {
+    .hero {
+      height: calc(100svh - 4.5rem);
+    }
+
     .hero__eyebrow,
     .hero__headline,
     .hero__support,
@@ -645,6 +654,12 @@ const gatherings = [
   @media (max-width: 767px) {
     .hero__actions {
       flex-direction: column;
+    }
+  }
+
+  @media (max-width: 400px) {
+    .hero__headline-pair > span {
+      white-space: normal;
     }
   }
 

--- a/src/components/sermon-featured.tsx
+++ b/src/components/sermon-featured.tsx
@@ -17,7 +17,7 @@ const secondaryButtonClass =
 export default function SermonFeatured({ sermon }: SermonFeaturedProps) {
   const [isPlaying, setIsPlaying] = useState(false);
 
-  const embedUrl = `https://www.youtube-nocookie.com/embed/${sermon.youtubeId}?autoplay=1&rel=0`;
+  const embedUrl = `https://www.youtube-nocookie.com/embed/${sermon.youtubeId}?autoplay=1&playsinline=1&rel=0`;
 
   return (
     <article className="animate-fade-up overflow-hidden rounded-2xl border border-border bg-linear-to-br from-accent/30 via-card to-card shadow-sm">

--- a/src/components/site-header.astro
+++ b/src/components/site-header.astro
@@ -373,16 +373,24 @@ const { pathname } = Astro.url;
     transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
   }
 
-  .site-header__link:hover,
-  .site-header__parent:hover,
   .site-header__link.is-active {
     color: #fff;
   }
 
-  .site-header__link:hover::after,
-  .site-header__parent:hover::after,
   .site-header__item--has-children:focus-within .site-header__parent::after {
     transform: scaleX(1);
+  }
+
+  @media (hover: hover) {
+    .site-header__link:hover,
+    .site-header__parent:hover {
+      color: #fff;
+    }
+
+    .site-header__link:hover::after,
+    .site-header__parent:hover::after {
+      transform: scaleX(1);
+    }
   }
 
   .site-header__caret {
@@ -461,6 +469,10 @@ const { pathname } = Astro.url;
     border-radius: 0.25rem;
     outline: 2px solid #fff;
     outline-offset: 2px;
+  }
+
+  .site-header__hamburger:active {
+    opacity: 0.7;
   }
 
   .site-header__hamburger span {
@@ -555,6 +567,10 @@ const { pathname } = Astro.url;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   }
 
+  .site-header__mobile-link:active {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
   .site-header__mobile-cta {
     display: flex;
     justify-content: center;
@@ -575,6 +591,10 @@ const { pathname } = Astro.url;
     font-size: 1rem;
     font-weight: 700;
     border-radius: 0.5rem;
+  }
+
+  .site-header__mobile-cta-btn:active {
+    background: #12813c;
   }
 
   @media (max-width: 380px) {

--- a/src/components/starwind/button/Button.astro
+++ b/src/components/starwind/button/Button.astro
@@ -30,13 +30,13 @@ export const button = tv({
       sm: "h-9 px-4 text-sm has-[>svg]:px-3 [&_svg:not([class*='size-'])]:size-3.5",
     },
     variant: {
-      cta: "bg-cta text-cta-foreground hover:bg-cta/90 focus-visible:ring-cta/50",
+      cta: "bg-cta text-cta-foreground hover:bg-cta/90 active:bg-cta/80 focus-visible:ring-cta/50",
       outline:
-        "bg-transparent text-white border border-white hover:bg-white/10 focus-visible:ring-white/50",
+        "bg-transparent text-white border border-white hover:bg-white/10 active:bg-white/15 focus-visible:ring-white/50",
       primary:
-        "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary/50",
+        "bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 focus-visible:ring-primary/50",
       secondary:
-        "bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-border focus-visible:ring-outline/50",
+        "bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/70 border border-border focus-visible:ring-outline/50",
     },
   },
 });

--- a/src/pages/salvation.astro
+++ b/src/pages/salvation.astro
@@ -665,11 +665,12 @@ const salvationContactHref = `mailto:${churchInfo.email}?subject=${encodeURIComp
       background-color 180ms ease,
       border-color 180ms ease,
       color 180ms ease,
-      transform 180ms ease;
+      transform 180ms ease,
+      opacity 180ms ease;
   }
 
-  .salvation-button:hover {
-    transform: translateY(-2px);
+  .salvation-button:active {
+    opacity: 0.9;
   }
 
   .salvation-button:focus-visible,
@@ -696,19 +697,10 @@ const salvationContactHref = `mailto:${churchInfo.email}?subject=${encodeURIComp
     box-shadow: 0 0.8rem 2.5rem rgba(0, 0, 0, 0.2);
   }
 
-  .salvation-button--light:hover {
-    background: var(--salvation-gold-light);
-  }
-
   .salvation-button--outline {
     border-color: rgba(255, 255, 255, 0.38);
     color: #fff;
     background: rgba(255, 255, 255, 0.04);
-  }
-
-  .salvation-button--outline:hover {
-    border-color: rgba(255, 255, 255, 0.75);
-    background: rgba(255, 255, 255, 0.1);
   }
 
   .salvation-button--cta {
@@ -717,8 +709,23 @@ const salvationContactHref = `mailto:${churchInfo.email}?subject=${encodeURIComp
     box-shadow: 0 1rem 2.5rem rgba(22, 163, 74, 0.2);
   }
 
-  .salvation-button--cta:hover {
-    background: #12813c;
+  @media (hover: hover) {
+    .salvation-button:hover {
+      transform: translateY(-2px);
+    }
+
+    .salvation-button--light:hover {
+      background: var(--salvation-gold-light);
+    }
+
+    .salvation-button--outline:hover {
+      border-color: rgba(255, 255, 255, 0.75);
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .salvation-button--cta:hover {
+      background: #12813c;
+    }
   }
 
   .hero-scripture {
@@ -735,6 +742,7 @@ const salvationContactHref = `mailto:${churchInfo.email}?subject=${encodeURIComp
       rgba(255, 255, 255, 0.035)
     );
     box-shadow: 0 2rem 5rem rgba(0, 0, 0, 0.2);
+    -webkit-backdrop-filter: blur(0.8rem);
     backdrop-filter: blur(0.8rem);
     animation: hero-card 1s 0.28s both cubic-bezier(0.22, 1, 0.36, 1);
   }
@@ -835,6 +843,7 @@ const salvationContactHref = `mailto:${churchInfo.email}?subject=${encodeURIComp
     z-index: 20;
     border-bottom: 1px solid var(--salvation-line);
     background: rgba(255, 253, 248, 0.96);
+    -webkit-backdrop-filter: blur(1rem);
     backdrop-filter: blur(1rem);
   }
 
@@ -865,8 +874,10 @@ const salvationContactHref = `mailto:${churchInfo.email}?subject=${encodeURIComp
     transition: background-color 180ms ease;
   }
 
-  .message-map a:hover {
-    background: rgba(201, 151, 63, 0.08);
+  @media (hover: hover) {
+    .message-map a:hover {
+      background: rgba(201, 151, 63, 0.08);
+    }
   }
 
   .map-number {
@@ -1686,8 +1697,10 @@ const salvationContactHref = `mailto:${churchInfo.email}?subject=${encodeURIComp
       transition: none;
     }
 
-    .salvation-button:hover {
-      transform: none;
+    @media (hover: hover) {
+      .salvation-button:hover {
+        transform: none;
+      }
     }
   }
 </style>

--- a/src/styles/starwind.css
+++ b/src/styles/starwind.css
@@ -189,6 +189,9 @@
   * {
     @apply border-border outline-outline/50;
   }
+  html {
+    -webkit-tap-highlight-color: rgba(15, 39, 68, 0.18);
+  }
   body {
     @apply bg-background text-foreground scheme-light dark:scheme-dark;
   }


### PR DESCRIPTION
## Summary
- Fix the homepage hero overflowing past the fold after the shared SiteHeader change by using `calc(100svh - 4.5rem)` below 900px
- Restore Safari backdrop blur on `/salvation/` with `-webkit-backdrop-filter`, and keep sermon video inline on iPhone via `playsinline=1`
- Gate hand-written `:hover` styles behind `@media (hover: hover)`, restore tap highlight, and add `:active` feedback for mobile controls and shared buttons
- Allow the hero headline to wrap below 400px so the Google Fonts swap fallback cannot clip on small phones

## Test plan
- [ ] Open `/` on an iPhone (or WebKit mobile emulation): hero should fit exactly under the sticky header with no 72px overflow
- [ ] Cold-load `/` on a 320–375px viewport with fonts blocked/slow: "Share the gospel." should wrap instead of clipping
- [ ] Open `/salvation/`: scripture card and message map should show backdrop blur in Safari
- [ ] On `/sermons/`, tap play: video should play inline instead of forcing fullscreen
- [ ] Tap salvation buttons and the mobile nav links: no sticky hover lift; brief active/tap feedback is visible
- [ ] Desktop (≥900px): homepage hero still full-bleed; morphing desktop nav unchanged


Made with [Cursor](https://cursor.com)