### PR TITLE
Fix iOS Safari mobile header flash on back/forward swipe

### DIFF
--- a/src/components/site-header.astro
+++ b/src/components/site-header.astro
@@ -160,6 +160,8 @@ const { pathname } = Astro.url;
     </div>
   </nav>
 </header>
+{/* Reserves flow height while the header is position:fixed on mobile. */}
+<div class="site-header__spacer" aria-hidden="true"></div>
 
 <script>
   const header = document.querySelector<HTMLElement>(".site-header");
@@ -206,6 +208,16 @@ const { pathname } = Astro.url;
     }
   };
 
+  // Close without the clip-path animation so Safari's back/forward snapshot
+  // never captures the navy overlay mid-collapse.
+  const closeMenuForNavigation = () => {
+    header?.classList.add("site-header--no-motion");
+    setMenuOpen(false, false);
+    window.requestAnimationFrame(() => {
+      header?.classList.remove("site-header--no-motion");
+    });
+  };
+
   const getFocusableElements = () => {
     const logo = header?.querySelector<HTMLAnchorElement>(".site-header__logo");
     return [logo, menuButton, ...mobileLinks, mobileCta].filter(
@@ -247,10 +259,10 @@ const { pathname } = Astro.url;
   });
 
   for (const link of mobileLinks) {
-    link.addEventListener("click", () => setMenuOpen(false, false));
+    link.addEventListener("click", closeMenuForNavigation);
   }
 
-  mobileCta?.addEventListener("click", () => setMenuOpen(false, false));
+  mobileCta?.addEventListener("click", closeMenuForNavigation);
 
   document.addEventListener("keydown", (event) => {
     if (!isMenuOpen()) {
@@ -269,6 +281,21 @@ const { pathname } = Astro.url;
       setMenuOpen(false, false);
     }
   });
+
+  // BFCache restore can replay in-flight header transitions; suppress for
+  // one frame so the restored page paints in its settled state.
+  window.addEventListener("pageshow", (event) => {
+    if (!event.persisted) {
+      return;
+    }
+    header?.classList.add("site-header--no-motion");
+    if (isMenuOpen()) {
+      setMenuOpen(false, false);
+    }
+    window.requestAnimationFrame(() => {
+      header?.classList.remove("site-header--no-motion");
+    });
+  });
 </script>
 
 <style>
@@ -283,14 +310,20 @@ const { pathname } = Astro.url;
     box-shadow: 0 1px 12px rgba(0, 0, 0, 0.18);
   }
 
+  .site-header__spacer {
+    display: none;
+  }
+
   .site-header__nav {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
+    min-height: 4.5rem;
     padding: 0.875rem 1.5rem;
     max-width: 80rem;
     margin-inline: auto;
+    box-sizing: border-box;
   }
 
   .site-header__logo {
@@ -607,6 +640,26 @@ const { pathname } = Astro.url;
     .site-header__hamburger span,
     .site-header__mobile {
       transition: none;
+    }
+  }
+
+  /* Instant close / bfcache restore — do not animate into Safari's snapshot. */
+  .site-header--no-motion .site-header__hamburger span,
+  .site-header--no-motion .site-header__mobile {
+    transition: none;
+  }
+
+  /* iOS WebKit mis-paints a sticky bar when the stuck state is recomputed
+     during history-restored scrolling; pin it and reserve its height instead. */
+  @media (max-width: 899px) {
+    .site-header {
+      position: fixed;
+      inset-inline: 0;
+    }
+
+    .site-header__spacer {
+      display: block;
+      height: 4.5rem;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On iOS Safari, swiping back/forward made the mobile header flash. Fresh link clicks were fine, and the issue did not show in Chrome's responsive mode.

Two WebKit-only causes:

1. **`position: sticky` re-paint on restored scroll** — Safari restores scroll around the same frame it swaps its gesture snapshot for the live page, forcing a sticky stuck-state recompute that mis-paints the header background for a frame.
2. **Snapshot captured mid-menu-close** — tapping a mobile nav link started the 400ms `clip-path` close, then navigated. Safari's back/forward snapshot could capture the navy overlay collapsing toward the hamburger.

## Changes

In `src/components/site-header.astro`:

- Pin the header with `position: fixed` below 900px and add an in-flow `.site-header__spacer` (`4.5rem`) so layout height matches the previous sticky header.
- Keep `position: sticky` at desktop (≥900px) where the nav can wrap and height is not constant.
- Add `min-height: 4.5rem` on `.site-header__nav` so header and spacer stay aligned (same constant already used by the homepage hero and salvation page).
- Close the mobile menu without animation before navigation (`site-header--no-motion`), and suppress header transitions for one frame on bfcache `pageshow`.

## Testing

Automated (Playwright, 390×844):

- Header is `position: fixed` on `/`, `/about-vbc/`, `/visit/`; height equals spacer (72px / `4.5rem`); main content starts immediately below spacer.
- Header stays pinned while scrolled; hamburger opens/closes; desktop (≥900px) remains `sticky` with spacer hidden; homepage `mobileOnly` header+spacer stay hidden at desktop.
- `pnpm build` succeeds.

Manual (Chrome mobile viewport + screen recording):

- Pinned header on homepage and about; content not obscured; menu open/close/navigate clean.
- Video: see PR artifacts / walkthrough.

Note: the original flash is an iOS WebKit compositing issue and is not reproducible in Chrome emulation — please confirm on-device with a back/forward swipe on the preview.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2223cde1-ccc9-4afe-b322-dc64e6f1ca00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2223cde1-ccc9-4afe-b322-dc64e6f1ca00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

