### PR TITLE
Always show SiteHeader on mobile; reveal after hero on desktop

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -563,6 +563,13 @@ const gatherings = [
     }
   }
 
+  @media (max-width: 899px) {
+    .hero {
+      /* Always-visible SiteHeader occupies 4.5rem on mobile. */
+      height: calc(100svh - 4.5rem);
+    }
+  }
+
   @media (max-width: 767px) {
     .hero__eyebrow,
     .hero__headline,

--- a/src/components/site-header.astro
+++ b/src/components/site-header.astro
@@ -4,7 +4,7 @@ import { giveHref, primaryNav, visitHref } from "@/lib/site-nav";
 
 interface Props {
   variant?: "solid" | "transparent";
-  /** When true, keep the header hidden until the homepage hero leaves the viewport. */
+  /** When true (desktop only), keep the header hidden until the homepage hero leaves the viewport. Mobile always shows the header. */
   revealAfterHero?: boolean;
 }
 
@@ -19,8 +19,6 @@ const { pathname } = Astro.url;
     revealAfterHero && "site-header--reveal-after-hero",
   ]}
   data-reveal-after-hero={revealAfterHero ? "" : undefined}
-  aria-hidden={revealAfterHero ? "true" : undefined}
-  inert={revealAfterHero ? true : undefined}
 >
   <nav class="site-header__nav" aria-label="Main navigation">
     <a
@@ -293,11 +291,29 @@ const { pathname } = Astro.url;
       return;
     }
     header.classList.toggle("is-visible", visible);
-    header.toggleAttribute("aria-hidden", !visible);
-    header.toggleAttribute("inert", !visible);
+    // Only inert/aria-hidden while the desktop reveal effect is hiding the bar.
+    const hideFromA11y = desktopMedia.matches && !visible;
+    header.toggleAttribute("aria-hidden", hideFromA11y);
+    header.toggleAttribute("inert", hideFromA11y);
     if (!visible && isMenuOpen()) {
       setMenuOpen(false, false);
     }
+  };
+
+  const syncRevealAfterHero = () => {
+    if (!revealAfterHero || !header) {
+      return;
+    }
+    // Mobile: always show. Desktop: show only once the hero has left view.
+    if (!desktopMedia.matches) {
+      setHeaderVisible(true);
+      return;
+    }
+    if (!hero) {
+      setHeaderVisible(true);
+      return;
+    }
+    setHeaderVisible(hero.getBoundingClientRect().bottom <= 0);
   };
 
   if (revealAfterHero && header && hero && "IntersectionObserver" in window) {
@@ -306,15 +322,20 @@ const { pathname } = Astro.url;
         if (!entry) {
           return;
         }
+        if (!desktopMedia.matches) {
+          setHeaderVisible(true);
+          return;
+        }
         setHeaderVisible(!entry.isIntersecting);
       },
       { threshold: 0 }
     );
 
     observer.observe(hero);
-  } else if (revealAfterHero && header && !hero) {
-    setHeaderVisible(true);
   }
+
+  syncRevealAfterHero();
+  desktopMedia.addEventListener("change", syncRevealAfterHero);
 
   // BFCache restore can replay in-flight header transitions; suppress for
   // one frame so the restored page paints in its settled state.
@@ -326,9 +347,7 @@ const { pathname } = Astro.url;
     if (isMenuOpen()) {
       setMenuOpen(false, false);
     }
-    if (revealAfterHero && header && hero) {
-      setHeaderVisible(hero.getBoundingClientRect().bottom <= 0);
-    }
+    syncRevealAfterHero();
     window.requestAnimationFrame(() => {
       header?.classList.remove("site-header--no-motion");
     });
@@ -342,19 +361,22 @@ const { pathname } = Astro.url;
     z-index: 40;
   }
 
-  .site-header--reveal-after-hero {
-    position: fixed;
-    inset-inline: 0;
-    top: 0;
-    width: 100%;
-    transform: translateY(-100%);
-    pointer-events: none;
-    transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
-  }
+  /* Desktop-only: hide until the hero scrolls away. Mobile always shows. */
+  @media (min-width: 900px) {
+    .site-header--reveal-after-hero {
+      position: fixed;
+      inset-inline: 0;
+      top: 0;
+      width: 100%;
+      transform: translateY(-100%);
+      pointer-events: none;
+      transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+    }
 
-  .site-header--reveal-after-hero.is-visible {
-    transform: none;
-    pointer-events: auto;
+    .site-header--reveal-after-hero.is-visible {
+      transform: none;
+      pointer-events: auto;
+    }
   }
 
   .site-header--solid {
@@ -714,11 +736,6 @@ const { pathname } = Astro.url;
     .site-header__spacer {
       display: block;
       height: 4.5rem;
-    }
-
-    /* Homepage reveal mode overlays until past the hero — no reserved gap. */
-    .site-header--reveal-after-hero + .site-header__spacer {
-      display: none;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On mobile, the homepage `SiteHeader` is always visible. The reveal-after-hero effect (header hidden until past the hero) is desktop-only (≥900px).

## Changes
- Scope `.site-header--reveal-after-hero` hide/slide styles to `min-width: 900px`
- JS: always show the header below the desktop breakpoint; IntersectionObserver only drives hide/show on desktop
- Restore mobile header spacer (no longer suppressed for `revealAfterHero`)
- Restore mobile hero height to `calc(100svh - 4.5rem)` so content clears the always-visible bar

## Verification

Mobile — header always visible on load:
[Mobile header always visible](https://cursor.com/agents/bc-fff2b8e5-a418-4f6f-956d-717bfe662e28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F10-mobile-header-always-visible.webp)

Desktop — no SiteHeader over hero (centered logo + links):
[Desktop hero without SiteHeader](https://cursor.com/agents/bc-fff2b8e5-a418-4f6f-956d-717bfe662e28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F12-desktop-hero-no-siteheader.webp)

Desktop — SiteHeader after scrolling past hero:
[Desktop header after hero](https://cursor.com/agents/bc-fff2b8e5-a418-4f6f-956d-717bfe662e28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F13-desktop-header-after-hero.webp)

## Test plan
- [x] Mobile: header visible on initial homepage load (with hamburger)
- [x] Mobile: hero sits below the header (no overlap / no missing spacer)
- [x] Desktop: no SiteHeader over the hero; centered logo + links remain in the hero
- [x] Desktop: SiteHeader appears after scrolling past the hero
- [ ] Other pages unchanged (header always visible)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fff2b8e5-a418-4f6f-956d-717bfe662e28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fff2b8e5-a418-4f6f-956d-717bfe662e28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

