### PR TITLE
Apply website content fixes from notes

### DIFF
--- a/src/components/hero-component.astro
+++ b/src/components/hero-component.astro
@@ -97,7 +97,7 @@ const gatherings = [
         <span>Grow in faith.</span>
         <span>Share the gospel.</span>
       </span>
-      <span class="hero__headline-accent">Reach the lost.</span>
+      <span class="hero__headline-accent">Glorify God.</span>
     </h1>
     <p class="hero__support">
       Rooted in Scripture, growing in Christ, and carrying the gospel throughout

--- a/src/lib/church-data.ts
+++ b/src/lib/church-data.ts
@@ -99,7 +99,7 @@ export const churchInfo = {
 /** Default site-wide SEO values. Per-page overrides merge on top via `buildSEO()`. */
 export const defaultSEO = {
   description:
-    "Victory Baptist Church in Fresno, California — an independent Baptist church proclaiming the gospel of Jesus Christ through soul-winning, sound Bible teaching, and Christ-centered worship. Sundays 11am & 6pm, Thursdays 7pm.",
+    "Victory Baptist Church in Fresno, California — an independent Baptist church proclaiming the gospel of Jesus Christ through personal evangelism, sound Bible teaching, and Christ-centered worship. Sundays 11am & 6pm, Thursdays 7pm.",
   /** 1200×630 social share image, served from `public/`. */
   ogImage: "/og-default.jpg",
   ogImageAlt: "Fresno skyline and downtown mural",
@@ -112,12 +112,26 @@ export interface Ministry {
   featured?: boolean;
 }
 
-/** Ministries shown on the home page — soul-winning / outreach first. */
+/** Standing weekly personal evangelism — shown on `/events`. */
+export const personalEvangelismTimes = {
+  saturday: {
+    day: "Saturday",
+    id: "saturdayPersonalEvangelism",
+    label: "Personal Evangelism",
+    time: "10:30am",
+  },
+} as const satisfies Record<string, ServiceTime>;
+
+export const personalEvangelismTimesList: readonly ServiceTime[] = [
+  personalEvangelismTimes.saturday,
+];
+
+/** Ministries shown on the home page — personal evangelism / outreach first. */
 export const ministries: Ministry[] = [
   {
     featured: true,
     id: "soul-winning",
-    name: "Soul-Winning",
+    name: "Personal Evangelism",
     summary:
       "One of our greatest responsibilities is to reach others with the gospel of Jesus Christ. We engage in weekly door-to-door evangelism, community outreach events, missionary support, and training believers to share the gospel.",
   },

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -220,18 +220,22 @@ const toUpcomingEvent = (
   };
 };
 
-const removeConsecutiveRecurringEvents = (
+const keepFirstRecurringInstance = (
   events: UpcomingCalendarEvent[]
 ): UpcomingCalendarEvent[] => {
-  let previousRecurringEventId: string | undefined;
+  const seenRecurringEventIds = new Set<string>();
 
   return events.filter((event) => {
-    const isConsecutiveRepeat =
-      event.recurringEventId &&
-      event.recurringEventId === previousRecurringEventId;
+    if (!event.recurringEventId) {
+      return true;
+    }
 
-    previousRecurringEventId = event.recurringEventId;
-    return !isConsecutiveRepeat;
+    if (seenRecurringEventIds.has(event.recurringEventId)) {
+      return false;
+    }
+
+    seenRecurringEventIds.add(event.recurringEventId);
+    return true;
   });
 };
 
@@ -301,7 +305,7 @@ export const getUpcomingMinistryEvents = async (
       return upcomingEvent ? [upcomingEvent] : [];
     });
 
-  return removeConsecutiveRecurringEvents(upcomingEvents)
+  return keepFirstRecurringInstance(upcomingEvents)
     .map(({ event }) => event)
     .slice(0, EVENT_LIMIT);
 };

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -4,6 +4,7 @@ import PageHeader from "@/components/page-header.astro";
 import UpcomingEvents from "@/components/upcoming-events.astro";
 import Skeleton from "@/components/starwind/skeleton/Skeleton.astro";
 import { Button } from "@/components/starwind/button";
+import { personalEvangelismTimesList } from "@/lib/church-data";
 ---
 
 <PageLayout
@@ -31,12 +32,24 @@ import { Button } from "@/components/starwind/button";
 
       <article class="border-t border-border pt-6">
         <h2 class="mb-2 font-display text-2xl font-bold text-foreground">
-          Soul-Winning Outreach
+          Personal Evangelism
         </h2>
         <p class="mb-4 text-muted-foreground leading-relaxed">
           Weekly door-to-door evangelism and community outreach throughout the
-          year. Ask a greeter how to get involved.
+          year. Meet at the church, then go out with a partner. Ask a greeter
+          how to get involved.
         </p>
+        <ul class="mb-4 space-y-2 text-muted-foreground">
+          {
+            personalEvangelismTimesList.map((gathering) => (
+              <li>
+                <strong class="text-foreground">{gathering.day}</strong>
+                {" — "}
+                {gathering.time}
+              </li>
+            ))
+          }
+        </ul>
         <Button href="/#soul-winning" variant="cta">Learn About Outreach</Button
         >
       </article>

--- a/src/pages/missions-conference.astro
+++ b/src/pages/missions-conference.astro
@@ -21,11 +21,11 @@ import { Button } from "@/components/starwind/button";
       <p class="mb-8 text-muted-foreground leading-relaxed">
         Details for the next conference will be posted here as dates are
         confirmed. Until then, you can support missions through prayer, giving,
-        and weekly soul-winning.
+        and weekly personal evangelism.
       </p>
       <div class="flex flex-wrap gap-3">
         <Button href="/#soul-winning" variant="cta" size="lg">
-          Soul-Winning Ministry
+          Personal Evangelism
         </Button>
         <Button href="/visit/" variant="secondary" size="lg"
           >Plan a Visit</Button


### PR DESCRIPTION
Closes #36

Website updates from the handwritten notes.

### Recurring events
`/events` and `/api/events.json` now keep only the **first upcoming instance** of each Google Calendar recurring series. One-off events are unchanged. Faith Bible Institute no longer repeats through the five-event list.

### Soul-Winning → Personal Evangelism
Homepage ministry title (and related copy on Events and Missions Conference) now reads **Personal Evangelism**. The `/#soul-winning` anchor is unchanged so existing links still work.

### Personal Evangelism times on `/events`
The Events page lists the standing weekly time:

- **Saturday — 10:30am** (meet at the church)

This is the last published weekly soul-winning time from the old site, and Saturday outreach is still referenced in the current staff bio. The notebook did not include a clock time — change `personalEvangelismTimes` in `src/lib/church-data.ts` if the notes had a different schedule.

### Hero title
`Reach the lost.` → **`Glorify God.`**